### PR TITLE
Fix #9 Comment highligting mistake

### DIFF
--- a/src/internal/QCXXHighlighter.cpp
+++ b/src/internal/QCXXHighlighter.cpp
@@ -64,7 +64,7 @@ QCXXHighlighter::QCXXHighlighter(QTextDocument* document) :
 
     // Single line
     m_highlightRules.append({
-        QRegularExpression(R"(/[^\n]*)"),
+        QRegularExpression(R"(//[^\n]*)"),
         "Comment"
     });
 }


### PR DESCRIPTION
`/` was set as one-line comment starter. changed it to `//` the correct one-line highlighter. It should fix #9 