### PR TITLE
Use Q_SLOTS macro instead of slots for boost signals compatability.

### DIFF
--- a/include/internal/QCodeEditor.hpp
+++ b/include/internal/QCodeEditor.hpp
@@ -106,7 +106,7 @@ public:
      */
     QCompleter* completer() const;
 
-public slots:
+public Q_SLOTS:
 
     /**
      * @brief Slot, that performs insertion of


### PR DESCRIPTION
The use of the Q_* macros will make the library more compatible and easier to integrate into other projects.